### PR TITLE
Added a pretty print style for BETA

### DIFF
--- a/source/includes/_measurements.md
+++ b/source/includes/_measurements.md
@@ -1,4 +1,4 @@
-# Measurements
+# Measurements `Beta`
 
 <aside class="notice">Note: Measurements are only available in the Tags Beta. Please <a href="mailto: support@librato.com" target="_top">contact Librato support</a> to join the beta.</aside>
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -384,6 +384,13 @@ html, body {
     margin-top: 2em;
     font-weight: 100;
     -webkit-font-smoothing: antialiased;
+    .prettyprint{
+      color: #323232;
+      vertical-align: top;
+      background-color: #ffecc6;
+      padding-left: 0.5em;
+      padding-right: 0.5em;
+    }
   }
 
   h1:first-child, div:first-child + h1 {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/559288/19092648/78e3dbaa-8a3c-11e6-9ec9-8d4bdd2fe364.png)

This adds a `Beta` Tag next to the title.  Since we use a JQuery plugin to create the list there wasn't a simple way to remove it from the sidebar.  
