### PR TITLE
Return 200 on chart update

### DIFF
--- a/source/includes/_charts.md
+++ b/source/includes/_charts.md
@@ -254,7 +254,26 @@ chart.save()
 >Response Code
 
 ```
-204 No Content
+200 OK
+```
+
+>Response Body
+
+```json
+{
+  "id": 1,
+  "name": "Temperature",
+  "type": "line",
+  "streams": [
+    {
+      "id": 1,
+      "metric": "temperature",
+      "type": "gauge",
+      "source": "*",
+      "group_function": "average"
+    }
+  ]
+}
 ```
 
 Updates attributes of a specific chart. In order to update the metrics associated with a chart you will need to view the example under [Create a Chart](#create-a-chart), which demonstrates overwriting an existing chart with new metrics.


### PR DESCRIPTION
We should merge this when we rollout the `api_chart_update_model` feature flag to 100%.

Depends on https://github.com/librato/api/pull/1414

/cc @jderrett @gmckeever 
