### PR TITLE
Persisted composites are PUTs

### DIFF
--- a/source/includes/_charts.md
+++ b/source/includes/_charts.md
@@ -293,7 +293,7 @@ curl \
     }
   ]
 }' \
--X PUT \
+-X POST \
 'https://metrics-api.librato.com/v1/spaces/:space_id/charts/:chart_id'
 ```
 


### PR DESCRIPTION
To create a persisted composite you have to use `PUT`. Somehow this was correct in SD but wrong in MD.