### PR TITLE
list all alerts

### DIFF
--- a/source/includes/_alerts.md
+++ b/source/includes/_alerts.md
@@ -889,9 +889,9 @@ for alert in api.list_alerts():
           "id": 1153,
           "type": "mail",
           "settings": {
-            "addresses": "me@domain.com"
+            "addresses": "foo@domain.com,bar@domain.com"
           },
-          "title": "My email"
+          "title": "Ops Team"
         }
       ],
       "attributes": {},


### PR DESCRIPTION
fixed a bug where it said “not available” instead of “import librato”

added list all alerts - it was missing. Showed the /status method
instead