### PR TITLE
Use an array of names

### DIFF
--- a/source/includes/_metrics.md
+++ b/source/includes/_metrics.md
@@ -140,7 +140,7 @@ Returns information for a specific metric.
 ```shell
 curl \
   -u $LIBRATO_USERNAME:$LIBRATO_TOKEN \
-  -d 'names=cpu&names=servers&names=reqs&period=60&display_min=0' \
+  -d 'names%5B%5D=cpu&names%5B%5D=servers&names%5B%5D=reqs&period=60&display_min=0' \
   -X PUT \
   'https://metrics-api.librato.com/v1/metrics'
 ```


### PR DESCRIPTION
Fixes https://www.librato.com/docs/api/#update-a-metric. `names` should be an array, unless I am mistaken.

<img width="374" alt="screen shot 2017-03-28 at 1 26 29 pm" src="https://cloud.githubusercontent.com/assets/1173886/24420951/42c15414-13ba-11e7-8ead-e17a74ebe744.png">
