### PR TITLE
Fix regex's for measurement restrictions

### DIFF
--- a/source/includes/_measurements.md
+++ b/source/includes/_measurements.md
@@ -357,9 +357,9 @@ Every response will include headers that define the current API limits related t
 
 Metric names must be 255 or fewer characters, and may only consist of `A-Za-z0-9.:-_`. The metric namespace is case insensitive.
 
-Tag names must match the regular expression `/\A[-.:_\w]+\z/{1,64}`. Tag names are always converted to lower case.
+Tag names must match the regular expression `/\A[-.:_\w]{1,64}\z/`. Tag names are always converted to lower case.
 
-Tag values must match the regular expression `/\A[-.:_\\/\w ]{1,255}\z`. Tag values are always converted to lower case.
+Tag values must match the regular expression `/\A[-.:_\\\/\w ]{1,255}\z/`. Tag values are always converted to lower case.
 
 Data streams have a default limit of **50** tag names per measurement.
 


### PR DESCRIPTION
The regular expressions defined under the "Measurement Restrictions" were slightly off and had syntax errors in them.

Tag name restrictions should now be correctly defined to be 1-64 in length.

Tag value restrictions should now be correctly defined to be able to contain '/' characters.